### PR TITLE
Update go-autocomplete.tsx

### DIFF
--- a/wc-go-autocomplete/src/components/go-autocomplete/go-autocomplete.tsx
+++ b/wc-go-autocomplete/src/components/go-autocomplete/go-autocomplete.tsx
@@ -149,7 +149,7 @@ export class GOAutocomplete {
     }
 
     return  <div onClick={(evt) => this.select(evt.target, doc) }>
-              <span class="autocomplete__item__label">{<a href={url_id} target="blank">{doc.label[0]}</a>}</span>
+              <span class="autocomplete__item__label">{<a href={url_id} target="blank">{doc.label}</a>}</span>
               <span class="autocomplete__item__taxon">{<a href={url_taxon} target="blank">{doc.taxon_label}</a>}</span>
             </div>
   }


### PR DESCRIPTION
@kltm Fix for https://github.com/geneontology/wc-ribbon/issues/46#issuecomment-2469864696

Note : at the time, the name of the genes was appearing so it seems it must have been an array at the time; for "bms", the request goes to :  https://api.geneontology.org/api/search/entity/autocomplete/bms?category=gene&rows=100